### PR TITLE
[feat] 알림페이지에 데이터를 출력한다

### DIFF
--- a/src/hooks/useFetchNotification.ts
+++ b/src/hooks/useFetchNotification.ts
@@ -1,0 +1,25 @@
+import { useState, useEffect } from 'react';
+import axios from 'axios';
+import Notification from '../types/Notification';
+import User from '../types/User';
+
+export default function useFetchNotification() {
+  const [data, setData] = useState<User | null>(null);
+
+  const url = 'https://kdt.frontend.5th.programmers.co.kr:5006/users/65fd7dd0ccdd3f59fe641487';
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const response = await axios.get(url);
+        setData(response.data);
+      } catch (err) {
+        console.error('요청 실패:', err);
+      }
+    };
+
+    fetchData();
+  }, []);
+
+  return { data };
+}

--- a/src/pages/NotificationPage.tsx
+++ b/src/pages/NotificationPage.tsx
@@ -1,29 +1,56 @@
 import Notice from '../components/Notice';
 import PageHeader from '../components/PageHeader';
+import useFetchNotification from '../hooks/useFetchNotification';
 import '../styles/css/NotificationPage.css'
+import Notification from '../types/Notification';
 
 const NotificationPage = () => {
+    const { data } = useFetchNotification();
+    console.log(data?.notifications);
+
+    const elapsedTime = (date: number): string => {
+        const start = new Date(date);
+        const end = new Date();
+    
+        const seconds = Math.floor((end.getTime() - start.getTime()) / 1000);
+        if (seconds < 60) return '방금 전';
+    
+        const minutes = seconds / 60;
+        if (minutes < 60) return `${Math.floor(minutes)}분 전`;
+    
+        const hours = minutes / 60;
+        if (hours < 24) return `${Math.floor(hours)}시간 전`;
+    
+        const days = hours / 24;
+        if (days < 7) return `${Math.floor(days)}일 전`;
+    
+        return `${start.toLocaleDateString()}`;
+    };
+
     return(
         <div className='page-container'>
             <PageHeader>알림</PageHeader>
             <div className="content-box">
-                <Notice />
-                <Notice />
-                <Notice />
-                <Notice />
-                <Notice />
-                <Notice />
-                <Notice />
-                <Notice />
-                <Notice />
-                <Notice />
-                <Notice />
-                <Notice />
-                <Notice />
-                <Notice />
-                <Notice />
-                <Notice />
-
+                {
+                    data?.notifications.map((notice: Notification) => {
+                        return(
+                            <div className={`notification-box ${notice.seen}`}>
+                                <div className='notice-content'>
+                                    <div className='profile-image-container'>
+                                        <img src={notice.author.image} />
+                                    </div>
+                                    <div className='notification-message'>
+                                        {notice.author.fullName}님이&nbsp;
+                                        {notice?.follow && <div>팔로우를 시작했습니다.</div>}
+                                        {notice?.comment && <div> 댓글을 달았습니다.</div>}
+                                        {(!notice?.comment && !notice.follow) && <div> 좋아합니다.</div>}
+                                    </div>
+                                </div>
+                                <div>{elapsedTime(new Date(notice.createdAt).getTime())}</div>
+                            </div>
+                        )
+                    })
+                }
             </div>
         </div>
     )

--- a/src/styles/css/NotificationPage.css
+++ b/src/styles/css/NotificationPage.css
@@ -1,6 +1,9 @@
 .content-box {
   padding-top: 57.2px;
 }
+.content-box .true {
+  color: #999999;
+}
 
 .notification-box {
   display: flex;
@@ -19,6 +22,16 @@
   display: flex;
   align-items: center;
 }
-.notice-content img {
-  padding-right: 15px;
+.notice-content .profile-image-container {
+  width: 55px;
+  height: 55px;
+}
+.notice-content .profile-image-container img {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+}
+.notice-content .notification-message {
+  display: flex;
+  padding-left: 10px;
 }

--- a/src/styles/css/NotificationPage.css
+++ b/src/styles/css/NotificationPage.css
@@ -2,7 +2,7 @@
   padding-top: 57.2px;
 }
 .content-box .true {
-  color: #999999;
+  color: #808080;
 }
 
 .notification-box {

--- a/src/styles/css/join.css
+++ b/src/styles/css/join.css
@@ -4,7 +4,7 @@ html, body {
   padding: 0;
 }
 
-.join-container {
+.form-container {
   display: flex;
   justify-content: center;
   align-items: center;

--- a/src/styles/scss/NotificationPage.scss
+++ b/src/styles/scss/NotificationPage.scss
@@ -2,7 +2,7 @@
     padding-top: 57.2px;
 
     .true{
-        color: #999999;
+        color: #808080;
     }
 }
 

--- a/src/styles/scss/NotificationPage.scss
+++ b/src/styles/scss/NotificationPage.scss
@@ -1,5 +1,9 @@
 .content-box{
     padding-top: 57.2px;
+
+    .true{
+        color: #999999;
+    }
 }
 
 .notification-box{
@@ -19,8 +23,19 @@
     display: flex;
     align-items: center;
 
-    img{
-        padding-right: 15px;
+    .profile-image-container{
+        width: 55px;
+        height: 55px;
+        img{
+            width: 100%;
+            height: 100%;
+            border-radius: 50%;
+        }
+    }
+
+    .notification-message{
+        display: flex;
+        padding-left: 10px;
     }
 
 }


### PR DESCRIPTION
### 👀 관련 이슈
>  해결하려는 문제가 무엇인가요 ?
 
* 알림페이지에 받아온 데이터를 출력합니다.

### ✨ 작업한 내용
> 작업한 내용을 적어주세요

* 알림을 제공한 사용자의 사진, 이름과 내용을 출력합니다.
* 읽은 알림은 회색으로 표시합니다.
* 알림이 생성된 시간을 기준으로, 60초 이내에는 방금 전, 60분 이내에는 n 분전, 24시간 이내에는 n시간 전, 일주일 이내에는 n일 전, 이후에는 날짜로 표시합니다.

### 🌀 PR Point
> 어떤 부분을 리뷰 받았으면 좋겠나요 ? 

* 읽은 알림을 표시한 색이 괜찮은지, 혹은 다른 형식의 표시가 필요할 지 말해주세요.

### 🍰 참고사항
>  추가로 남길 메모가 있으신가요 ?

* 현재는 데이터를 받아오는 방식이 올바르지 않습니다. 알림을 조회하려면 토큰이 필요하기 때문에, API에서 한 유저를 조회했을 때 볼 수 있는 알림목록을 통해 접근했습니다. 로그인 시 토큰을 저장하는 기능을 구현한 후에 모두 수정하도록 하겠습니다.

* 앞으로 저희는 어떤 동작을 했을 때 읽음 처리를 할 것인지 논의가 필요합니다. 저는 알림을 클릭했을 때 읽었다고 처리하는 것과 알림페이지를 방문했을 때 모든 알림을 읽었다고 처리하는 두 가지 방법이 생각나는데, 더 좋은 방법이 있다면 말해주세요. 

* 추가적으로 알림을 클릭했을 때 발생하는 이벤트(페이지 이동이나 애니메이션)에 대해서도 말해주세요 ! 

* 최대 알림의 갯수를 정할 것인지, 아니면 몇 일 이내에 발생한 알림만 보여줄 것인지에 대한 논의도 필요할 것 같습니다.

### 📷 스크린샷 또는 GIF
